### PR TITLE
Add onboarding coordinator to manage onboarding steps

### DIFF
--- a/PulseTempo/PulseTempoApp.swift
+++ b/PulseTempo/PulseTempoApp.swift
@@ -26,8 +26,7 @@ struct AppCoordinator: View {
             ActiveRunView()
         } else {
             // Onboarding flow
-            WelcomeView {
-                // When user taps "Get Started", move to main app
+            OnboardingCoordinator {
                 withAnimation {
                     hasCompletedOnboarding = true
                 }

--- a/PulseTempo/Views/Onboarding/OnboardingCoordinator.swift
+++ b/PulseTempo/Views/Onboarding/OnboardingCoordinator.swift
@@ -1,0 +1,174 @@
+import SwiftUI
+import HealthKit
+import MusicKit
+
+/// Coordinates the multi-step onboarding flow, guiding the user through
+/// welcome messaging and permission prompts before entering the main app.
+struct OnboardingCoordinator: View {
+
+    /// Represents the current step in the onboarding experience.
+    enum OnboardingStep {
+        case welcome
+        case healthKit
+        case musicKit
+    }
+
+    // MARK: - Properties
+
+    /// Callback fired when onboarding has completed and the user can enter the app.
+    var onFinished: () -> Void
+
+    // MARK: - State
+
+    /// Tracks the current onboarding step that should be displayed to the user.
+    @State private var currentStep: OnboardingStep = .welcome
+
+    /// Most recent HealthKit authorization status.
+    @State private var healthAuthorizationStatus: HKAuthorizationStatus = .notDetermined
+
+    /// Most recent MusicKit authorization status.
+    @State private var musicAuthorizationStatus: MusicAuthorization.Status = .notDetermined
+
+    /// Prevents firing the completion handler multiple times.
+    @State private var didFinishOnboarding = false
+
+    // MARK: - Derived State
+
+    /// Indicates whether HealthKit permissions have been granted.
+    private var isHealthAuthorized: Bool {
+        healthAuthorizationStatus == .sharingAuthorized
+    }
+
+    /// Indicates whether MusicKit permissions have been granted.
+    private var isMusicAuthorized: Bool {
+        musicAuthorizationStatus == .authorized
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Group {
+            switch currentStep {
+            case .welcome:
+                WelcomeView {
+                    advanceFromWelcome()
+                }
+
+            case .healthKit:
+                HealthKitPermissionView(
+                    authorizationStatus: healthAuthorizationStatus,
+                    onRequestAuthorization: requestHealthKitAuthorization,
+                    onContinue: advanceFromHealthKit
+                )
+
+            case .musicKit:
+                MusicKitPermissionView(
+                    authorizationStatus: musicAuthorizationStatus,
+                    onRequestAuthorization: requestMusicKitAuthorization,
+                    onContinue: advanceFromMusicKit
+                )
+            }
+        }
+        .task {
+            refreshAuthorizationStates()
+        }
+        .onChange(of: healthAuthorizationStatus) { _ in
+            reevaluateFlow()
+        }
+        .onChange(of: musicAuthorizationStatus) { _ in
+            reevaluateFlow()
+        }
+    }
+
+    // MARK: - Flow Control
+
+    /// Reads the current permission states and updates onboarding flow accordingly.
+    private func refreshAuthorizationStates() {
+        healthAuthorizationStatus = HealthKitManager.shared.getAuthorizationStatus()
+        musicAuthorizationStatus = MusicKitManager.shared.authorizationStatus
+        reevaluateFlow()
+    }
+
+    /// Determines whether additional onboarding steps are needed or if we can finish.
+    private func reevaluateFlow() {
+        if isHealthAuthorized && isMusicAuthorized {
+            finishOnboarding()
+            return
+        }
+
+        switch currentStep {
+        case .welcome:
+            // Stay on the welcome step until the user taps "Get Started".
+            break
+        case .healthKit:
+            if isHealthAuthorized {
+                currentStep = .musicKit
+            }
+        case .musicKit:
+            if !isHealthAuthorized {
+                currentStep = .healthKit
+            }
+        }
+    }
+
+    /// Advances from the welcome screen to the next required step, if any.
+    private func advanceFromWelcome() {
+        if !isHealthAuthorized {
+            currentStep = .healthKit
+        } else if !isMusicAuthorized {
+            currentStep = .musicKit
+        } else {
+            finishOnboarding()
+        }
+    }
+
+    /// Advances from the HealthKit step if authorization has been granted.
+    private func advanceFromHealthKit() {
+        guard isHealthAuthorized else {
+            return
+        }
+
+        if isMusicAuthorized {
+            finishOnboarding()
+        } else {
+            currentStep = .musicKit
+        }
+    }
+
+    /// Advances from the MusicKit step if authorization has been granted.
+    private func advanceFromMusicKit() {
+        guard isMusicAuthorized else {
+            return
+        }
+
+        finishOnboarding()
+    }
+
+    /// Sends the user into the main app experience by invoking `onFinished` once.
+    private func finishOnboarding() {
+        guard !didFinishOnboarding else { return }
+        didFinishOnboarding = true
+        onFinished()
+    }
+
+    // MARK: - Authorization Helpers
+
+    /// Requests HealthKit authorization and updates the stored status once complete.
+    private func requestHealthKitAuthorization() {
+        HealthKitManager.shared.requestAuthorization { success, _ in
+            healthAuthorizationStatus = HealthKitManager.shared.getAuthorizationStatus()
+
+            if success {
+                advanceFromHealthKit()
+            }
+        }
+    }
+
+    /// Requests MusicKit authorization and updates the stored status once complete.
+    private func requestMusicKitAuthorization() {
+        MusicKitManager.shared.requestAuthorization { status in
+            musicAuthorizationStatus = status
+            advanceFromMusicKit()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an onboarding coordinator that tracks welcome, HealthKit, and MusicKit steps
- load initial authorization states and request permissions when onboarding views trigger actions
- integrate the coordinator into the app shell so completion hands control to the main run experience

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_690cf34572a48332874f80737b1014ce