### PR TITLE
Persist onboarding completion and refresh permissions

### DIFF
--- a/PulseTempo/Views/Onboarding/HealthKitPermissionView.swift
+++ b/PulseTempo/Views/Onboarding/HealthKitPermissionView.swift
@@ -23,6 +23,20 @@ struct HealthKitPermissionView: View {
     /// Optional callback when the user chooses to skip
     var onSkip: (() -> Void)?
 
+    private let healthKitManager: HealthKitManager
+
+    init(
+        healthKitManager: HealthKitManager = .shared,
+        onAuthorized: @escaping () -> Void,
+        onBack: (() -> Void)? = nil,
+        onSkip: (() -> Void)? = nil
+    ) {
+        self.healthKitManager = healthKitManager
+        self.onAuthorized = onAuthorized
+        self.onBack = onBack
+        self.onSkip = onSkip
+    }
+
     // MARK: - State
 
     @State private var authorizationStatus: HKAuthorizationStatus = .notDetermined
@@ -200,7 +214,7 @@ struct HealthKitPermissionView: View {
     // MARK: - Actions
 
     private func refreshAuthorizationStatus() {
-        authorizationStatus = HealthKitManager.shared.getAuthorizationStatus()
+        authorizationStatus = healthKitManager.getAuthorizationStatus()
     }
 
     private func requestAuthorization() {
@@ -212,7 +226,7 @@ struct HealthKitPermissionView: View {
         isRequesting = true
         errorMessage = nil
 
-        HealthKitManager.shared.requestAuthorization { success, error in
+        healthKitManager.requestAuthorization { success, error in
             isRequesting = false
             refreshAuthorizationStatus()
 

--- a/PulseTempo/Views/Onboarding/MusicKitPermissionView.swift
+++ b/PulseTempo/Views/Onboarding/MusicKitPermissionView.swift
@@ -32,14 +32,18 @@ struct MusicKitPermissionView: View {
     @State private var hasSubscription: Bool?
     @State private var errorMessage: String?
 
+    private let musicKitManager: MusicKitManager
+
     // MARK: - Initialization
 
     init(
         initialStatus: MusicAuthorization.Status = .notDetermined,
+        musicKitManager: MusicKitManager = .shared,
         onAuthorized: @escaping () -> Void,
         onBack: (() -> Void)? = nil,
         onSkip: (() -> Void)? = nil
     ) {
+        self.musicKitManager = musicKitManager
         self.onAuthorized = onAuthorized
         self.onBack = onBack
         self.onSkip = onSkip
@@ -284,7 +288,7 @@ struct MusicKitPermissionView: View {
 
     @MainActor
     private func refreshAuthorizationStatus() {
-        let status = MusicKitManager.shared.authorizationStatus
+        let status = musicKitManager.authorizationStatus
         apply(status)
     }
 
@@ -295,7 +299,7 @@ struct MusicKitPermissionView: View {
         errorMessage = nil
 
         Task {
-            await MusicKitManager.shared.requestAuthorization { status in
+            await musicKitManager.requestAuthorization { status in
                 Task { @MainActor in
                     isRequesting = false
                     apply(status)
@@ -331,7 +335,7 @@ struct MusicKitPermissionView: View {
             guard authorizationStatus == .authorized else { return }
 
             isCheckingSubscription = true
-            let subscribed = await MusicKitManager.shared.checkSubscriptionStatus()
+            let subscribed = await musicKitManager.checkSubscriptionStatus()
             hasSubscription = subscribed
             isCheckingSubscription = false
         }
@@ -355,7 +359,7 @@ struct MusicKitPermissionView: View {
     private func presentSubscriptionOffer() {
         Task { @MainActor in
             isCheckingSubscription = true
-            MusicKitManager.shared.presentSubscriptionOffer()
+            musicKitManager.presentSubscriptionOffer()
             // After presenting the offer, optimistically assume the user may subscribe.
             isCheckingSubscription = false
             updateSubscriptionStatus()


### PR DESCRIPTION
## Summary
- persist the onboarding completion flag in AppCoordinator and optionally bypass it for debug runs
- inject shared HealthKit and MusicKit managers into the onboarding flow and propagate them to the permission steps
- refresh authorization states when the onboarding coordinator resumes to keep the flow in sync with system settings

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_690cf6c8bf548332bb2f1d5ab536df25