### PR TITLE
Ensure playlist storage cleans suite domains

### DIFF
--- a/PulseTempo/Services/PlaylistStorageManager.swift
+++ b/PulseTempo/Services/PlaylistStorageManager.swift
@@ -22,9 +22,11 @@ final class PlaylistStorageManager: PlaylistStorageManaging {
     static let shared = PlaylistStorageManager()
 
     private let userDefaults: UserDefaults
+    private let suiteName: String?
 
-    init(userDefaults: UserDefaults = .standard) {
+    init(userDefaults: UserDefaults = .standard, suiteName: String? = nil) {
         self.userDefaults = userDefaults
+        self.suiteName = suiteName
     }
     
     // MARK: - Storage Keys
@@ -50,7 +52,12 @@ final class PlaylistStorageManager: PlaylistStorageManaging {
     
     /// Clear all saved playlist selections
     func clearSelectedPlaylists() {
-        userDefaults.removeObject(forKey: StorageKey.selectedPlaylistIds)
+        if let suiteName {
+            // Clearing the entire suite ensures stale test data doesn't linger between runs
+            userDefaults.removePersistentDomain(forName: suiteName)
+        } else {
+            userDefaults.removeObject(forKey: StorageKey.selectedPlaylistIds)
+        }
         print("🗑️ Cleared saved playlist selections")
     }
     

--- a/PulseTempoTests/Integration/IntegrationFlowTests.swift
+++ b/PulseTempoTests/Integration/IntegrationFlowTests.swift
@@ -44,11 +44,11 @@ final class IntegrationFlowTests: XCTestCase {
             return XCTFail("Failed to create user defaults suite")
         }
 
-        let storage = PlaylistStorageManager(userDefaults: defaults)
+        let storage = PlaylistStorageManager(userDefaults: defaults, suiteName: suiteName)
         storage.clearSelectedPlaylists()
         storage.saveSelectedPlaylists(["abc"])
 
-        let reloaded = PlaylistStorageManager(userDefaults: defaults)
+        let reloaded = PlaylistStorageManager(userDefaults: defaults, suiteName: suiteName)
         XCTAssertEqual(reloaded.loadSelectedPlaylists(), ["abc"])
     }
 

--- a/PulseTempoTests/Services/PlaylistStorageManagerTests.swift
+++ b/PulseTempoTests/Services/PlaylistStorageManagerTests.swift
@@ -9,7 +9,10 @@ final class PlaylistStorageManagerTests: XCTestCase {
         super.setUp()
         userDefaults = UserDefaults(suiteName: "PlaylistStorageManagerTests")
         userDefaults.removePersistentDomain(forName: "PlaylistStorageManagerTests")
-        storageManager = PlaylistStorageManager(userDefaults: userDefaults)
+        storageManager = PlaylistStorageManager(
+            userDefaults: userDefaults,
+            suiteName: "PlaylistStorageManagerTests"
+        )
     }
 
     override func tearDown() {
@@ -35,7 +38,10 @@ final class PlaylistStorageManagerTests: XCTestCase {
 
     func testPersistenceAcrossInstances() {
         storageManager.saveSelectedPlaylists(["10", "20"])
-        let newManager = PlaylistStorageManager(userDefaults: userDefaults)
+        let newManager = PlaylistStorageManager(
+            userDefaults: userDefaults,
+            suiteName: "PlaylistStorageManagerTests"
+        )
         XCTAssertEqual(newManager.loadSelectedPlaylists(), ["10", "20"])
     }
 


### PR DESCRIPTION
## Summary
- add suiteName awareness to PlaylistStorageManager so test suites can clear persistent domains cleanly
- update storage and integration tests to pass suite identifiers for deterministic cleanup

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b849d391483328ad2e38cb14793c7)