### PR TITLE
Use isolated UserDefaults suite in onboarding integration test

### DIFF
--- a/PulseTempoTests/Integration/IntegrationFlowTests.swift
+++ b/PulseTempoTests/Integration/IntegrationFlowTests.swift
@@ -2,21 +2,57 @@ import XCTest
 @testable import PulseTempo
 
 final class IntegrationFlowTests: XCTestCase {
+
+    private let onboardingSuiteName = "IntegrationFlowTests.OnboardingFlow"
+    private let playlistKey = "selectedPlaylistIds"
+    private var onboardingDefaults: UserDefaults!
+    private var onboardingStorage: PlaylistStorageManager!
+    private var homeViewModel: HomeViewModel?
+
+    override func setUp() {
+        super.setUp()
+
+        UserDefaults.standard.set(["standard-sentinel"], forKey: playlistKey)
+
+        guard let defaults = UserDefaults(suiteName: onboardingSuiteName) else {
+            XCTFail("Failed to create user defaults suite")
+            return
+        }
+
+        onboardingDefaults = defaults
+        onboardingDefaults.removePersistentDomain(forName: onboardingSuiteName)
+        onboardingStorage = PlaylistStorageManager(userDefaults: onboardingDefaults, suiteName: onboardingSuiteName)
+    }
+
+    override func tearDown() {
+        homeViewModel = nil
+        onboardingStorage = nil
+
+        onboardingDefaults?.removePersistentDomain(forName: onboardingSuiteName)
+        onboardingDefaults = nil
+
+        UserDefaults.standard.removeObject(forKey: playlistKey)
+
+        super.tearDown()
+    }
     
     func testOnboardingFlowPersistsPlaylists() {
-        let storage = MockPlaylistStorageManager()
         let mockMusic = MockMusicService()
         let playlists = [MusicPlaylist(id: "p1", name: "Warmup", trackCount: 2, artwork: nil)]
         mockMusic.fetchUserPlaylistsHandler = { completion in completion(.success(playlists)) }
 
-        let homeViewModel = HomeViewModel(musicService: mockMusic, storageManager: storage)
-        homeViewModel.saveSelectedPlaylists(playlists.map { $0.id })
-        XCTAssertTrue(storage.hasSelectedPlaylists)
+        homeViewModel = HomeViewModel(musicService: mockMusic, storageManager: onboardingStorage)
+        homeViewModel?.saveSelectedPlaylists(playlists.map { $0.id })
+        XCTAssertTrue(onboardingStorage.hasSelectedPlaylists)
 
-        homeViewModel.refreshPlaylists()
+        XCTAssertEqual(onboardingStorage.loadSelectedPlaylists(), playlists.map { $0.id })
+        XCTAssertEqual(onboardingDefaults.stringArray(forKey: playlistKey), playlists.map { $0.id })
+        XCTAssertEqual(UserDefaults.standard.stringArray(forKey: playlistKey), ["standard-sentinel"], "Should avoid reading from .standard during onboarding persistence")
+
+        homeViewModel?.refreshPlaylists()
         waitForMainQueue()
 
-        XCTAssertEqual(homeViewModel.selectedPlaylists, playlists)
+        XCTAssertEqual(homeViewModel?.selectedPlaylists, playlists)
     }
 
     func testWorkoutFlowNavigationBetweenTracks() {


### PR DESCRIPTION
## Summary
- initialize the onboarding integration test with a dedicated UserDefaults suite
- add setup/teardown to clean the suite after references are released and assert standard defaults remain untouched

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b8a93b5ec83328c61ec6a680524df)